### PR TITLE
Clear about page

### DIFF
--- a/src/routes/about/+page.svx
+++ b/src/routes/about/+page.svx
@@ -1,11 +1,1 @@
-<script>
-  import Readme from '../../../README.md'
-</script>
-
-SwyxKit is a blog template meant for frontend developers who want to get a performant, fully featured content site up and running with SvelteKit, Tailwind CSS, and other blog features (listed below).
-
-Below is the full README.md you get from the github repo: https://github.com/sw-yx/swyxkit
-
----
-
-<Readme />
+<h1>About swyxkit!</h1>

--- a/src/routes/about/+page.svx
+++ b/src/routes/about/+page.svx
@@ -1,1 +1,5 @@
-<h1>About swyxkit!</h1>
+<script>
+  import { SITE_TITLE } from '$lib/siteConfig';
+</script>
+
+<h1>About {SITE_TITLE}!</h1>


### PR DESCRIPTION
## Summary
- remove README content from the About page so it's empty except for a heading

## Testing
- `npm test --silent` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fb0f1cfd08324b30e347814975e27